### PR TITLE
add better support for different reader type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,19 @@
 
+## 0.6.0 (2021-03-23)
+
+* add dynamic dependency injection to better support multiple reader types (https://github.com/developmentseed/rio-viz/pull/28)
+* add better UI for MultiBaseReader (e.g STAC)
+* renamed `indexes` query parameter to `bidx`
+* update bands/assets/indexes query parameter style to follow the common specification
+
+```
+# before
+/tiles/9/150/189?indexes=1,2,3
+
+# now
+/tiles/9/150/189?bidx=1&bidx=2&bidx=3
+```
+
 ## 0.5.0 (2021-03-01)
 
 * renamed `rio_viz.ressources` to `rio_viz.resources` (https://github.com/developmentseed/titiler/pull/210)

--- a/README.md
+++ b/README.md
@@ -36,14 +36,13 @@ $ pip install -U pip cython==0.28
 $ pip install rio-viz["mvt"]
 ```
 
-Built from source
+Build from source
 
 ```bash
 $ git clone https://github.com/developmentseed/rio-viz.git
 $ cd rio-viz
 $ pip install -e .
 ```
-
 
 ## CLI
 
@@ -63,7 +62,7 @@ Options:
   --mapbox-token TOKEN       Pass Mapbox token
   --no-check                 Ignore COG validation
   --reader TEXT              rio-tiler Reader (BaseReader or AsyncBaseReader). Default is `rio_tiler.io.COGReader`
-  --layers TEXT              limit to specific layers (indexes, bands, assets)
+  --layers TEXT              limit to specific layers (for Multi* readers)
   --server-only              Launch API without opening the rio-viz web-page.
   --config NAME=VALUE        GDAL configuration options.
   --help                     Show this message and exit.
@@ -86,12 +85,20 @@ rio-viz support multiple/custom reader as long they are subclass of `rio_tiler.i
 $ rio viz "cog_band{2,3,4}.tif" \
   --reader rio_viz.io.reader.MultiFilesReader
 
+# MultiBandReader
 # Landsat 8 - rio-tiler-pds
+# We use `--layers` to limit the number of bands
 $ rio viz LC08_L1TP_013031_20130930_20170308_01_T1 \
   --reader rio_tiler_pds.landsat.aws.landsat8.L8Reader \
   --layers B1,B2 \
   --config GDAL_DISABLE_READDIR_ON_OPEN=FALSE \
   --config CPL_VSIL_CURL_ALLOWED_EXTENSIONS=".TIF,.ovr"
+
+# MultiBaseReader
+# We use `--layers` to limit the number of assets
+rio viz https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2A_34SGA_20200318_0_L2A \
+  --reader rio_tiler.io.STACReader \
+  --layers B04,B03,B02
 
 # aiocogeo
 $ rio viz https://naipblobs.blob.core.windows.net/naip/v002/al/2019/al_60cm_2019/30087/m_3008701_ne_16_060_20191115.tif \
@@ -124,7 +131,6 @@ $ curl http://127.0.0.1:8080/info | jq
 You can see the full API documentation over `http://127.0.0.1:8080/docs`
 
 ![API documentation](https://user-images.githubusercontent.com/10407788/99135093-a7a53b80-25ee-11eb-98ba-0ce932775791.png)
-
 
 ## Contribution & Development
 

--- a/rio_viz/app.py
+++ b/rio_viz/app.py
@@ -204,6 +204,11 @@ class viz:
                         resampling_method=image_params.resampling_method.name,
                         **kwargs,
                     )
+
+                    bandnames = kwargs.get("bands", kwargs.get("assets", None)) or [
+                        f"{ix + 1}" for ix in range(tile_data.count)
+                    ]
+
                     dst_colormap = getattr(src_dst, "colormap", None)
             timings.append(("dataread", round(t.elapsed * 1000, 2)))
 
@@ -215,10 +220,6 @@ class viz:
                     )
 
                 _mvt_encoder = partial(run_in_threadpool, mvt_encoder)
-
-                bandnames = layer_params.kwargs.get(
-                    "bands", layer_params.kwargs.get("assets", None)
-                ) or [f"{ix + 1}" for ix in range(tile_data.count)]
 
                 with Timer() as t:
                     content = await _mvt_encoder(

--- a/rio_viz/app.py
+++ b/rio_viz/app.py
@@ -510,12 +510,13 @@ class viz:
 
             tile_url = request.url_for("tile", **kwargs)
 
-            qs = str(request.query_params)
-            if "tile_format" in qs:
-                qs = qs.replace(f"tile_format={tile_format.value}", "")
-
+            qs = [
+                (key, value)
+                for (key, value) in request.query_params._list
+                if key != "tile_format"
+            ]
             if qs:
-                tile_url += f"?{qs}"
+                tile_url += f"?{urllib.parse.urlencode(qs)}"
 
             async with self.reader(self.src_path) as src_dst:  # type: ignore
                 bounds = src_dst.bounds

--- a/rio_viz/app.py
+++ b/rio_viz/app.py
@@ -511,9 +511,10 @@ class viz:
             tile_url = request.url_for("tile", **kwargs)
 
             qs = str(request.query_params)
+            if "tile_format" in qs:
+                qs = qs.replace(f"tile_format={tile_format.value}", "")
+
             if qs:
-                if "tile_format" in qs:
-                    qs = qs.replace(f"tile_format={tile_format.value}", "")
                 tile_url += f"?{qs}"
 
             async with self.reader(self.src_path) as src_dst:  # type: ignore

--- a/rio_viz/app.py
+++ b/rio_viz/app.py
@@ -19,7 +19,13 @@ from starlette.templating import Jinja2Templates
 from rio_tiler.io import AsyncBaseReader
 from rio_tiler.models import Info, Metadata
 
-from .dependencies import ImageParams
+from .dependencies import (
+    AssetsParams,
+    BandsParams,
+    DefaultDependency,
+    ImageParams,
+    IndexesParams,
+)
 from .models.mapbox import TileJSON
 from .resources.enums import ImageType, TileType
 from .resources.responses import ImageResponse, XMLResponse
@@ -59,11 +65,37 @@ class viz:
     layers: Optional[str] = attr.ib(default=None)
     nodata: Optional[Union[str, int, float]] = attr.ib(default=None)
 
+    # cog / bands / assets
+    reader_type: str = attr.ib(default="cog")
+
     router: Optional[APIRouter] = attr.ib(init=False)
+
+    layer_dependency: Type[DefaultDependency] = attr.ib(init=False)
+
+    @reader_type.validator
+    def check(self, attribute, value):
+        """Validate reader_type."""
+        if value not in ["cog", "bands", "assets"]:
+            raise ValueError("`reader_type` must be one of `cog, bands or assets`")
 
     def __attrs_post_init__(self):
         """Update App."""
         self.router = APIRouter()
+
+        if self.reader_type == "cog":
+            self.layer_dependency = IndexesParams
+        elif self.reader_type == "bands":
+            self.layer_dependency = type(
+                "BandsParams",
+                (BandsParams,),
+                {"default_band": self.layers.split(",") if self.layers else None},
+            )
+        elif self.reader_type == "assets":
+            self.layer_dependency = type(
+                "AssetsParams",
+                (AssetsParams,),
+                {"default_asset": self.layers.split(",") if self.layers else None},
+            )
 
         self.register_middleware()
         self.register_routes()
@@ -80,30 +112,17 @@ class viz:
         )
         self.app.add_middleware(GZipMiddleware, minimum_size=0)
 
-    def _get_options(self, src_dst, indexes: Optional[str] = None):
+    def _get_options(self, src_dst, options: Dict[str, Any]):
         """Create Reader options."""
-        kwargs: Dict[str, Any] = {}
-
         assets = getattr(src_dst, "assets", None)
+        if assets and not options.get("assets"):
+            options["assets"] = assets
+
         bands = getattr(src_dst, "bands", None)
+        if bands and not options.get("bands"):
+            options["bands"] = bands
 
-        if indexes:
-            if assets:
-                kwargs["assets"] = indexes.split(",")
-            elif bands:
-                kwargs["bands"] = indexes.split(",")
-            else:
-                kwargs["indexes"] = tuple(int(s) for s in indexes.split(","))
-        else:
-            if assets:
-                kwargs["assets"] = self.layers.split(",") if self.layers else assets
-            if bands:
-                kwargs["bands"] = self.layers.split(",") if self.layers else bands
-
-        if self.nodata is not None:
-            kwargs["nodata"] = self.nodata
-
-        return kwargs
+        return options
 
     def register_routes(self):
         """Register routes to the FastAPI app."""
@@ -152,9 +171,7 @@ class viz:
             y: int,
             scale: int = Query(2, gt=0, lt=4),
             format: Optional[TileType] = None,
-            indexes: Optional[str] = Query(
-                None, description="Coma (',') delimited band indexes"
-            ),
+            layer_params=Depends(self.layer_dependency),
             image_params: ImageParams = Depends(),
             feature_type: str = Query(
                 None,
@@ -173,7 +190,12 @@ class viz:
 
             with Timer() as t:
                 async with self.reader(self.src_path) as src_dst:  # type: ignore
-                    kwargs = self._get_options(src_dst, indexes)
+
+                    # Adapt options for each reader type
+                    kwargs = self._get_options(src_dst, layer_params.kwargs)
+                    if self.nodata is not None:
+                        kwargs["nodata"] = self.nodata
+
                     tile_data = await src_dst.tile(
                         x,
                         y,
@@ -182,12 +204,7 @@ class viz:
                         resampling_method=image_params.resampling_method.name,
                         **kwargs,
                     )
-                    colormap = image_params.colormap or getattr(
-                        src_dst, "colormap", None
-                    )
-                    bands = kwargs.get("bands", kwargs.get("assets", None)) or [
-                        f"{ix + 1}" for ix in range(tile_data.count)
-                    ]
+                    dst_colormap = getattr(src_dst, "colormap", None)
             timings.append(("dataread", round(t.elapsed * 1000, 2)))
 
             if format and format in [TileType.pbf, TileType.mvt]:
@@ -199,11 +216,15 @@ class viz:
 
                 _mvt_encoder = partial(run_in_threadpool, mvt_encoder)
 
+                bandnames = layer_params.kwargs.get(
+                    "bands", layer_params.kwargs.get("assets", None)
+                ) or [f"{ix + 1}" for ix in range(tile_data.count)]
+
                 with Timer() as t:
                     content = await _mvt_encoder(
                         tile_data.data,
                         tile_data.mask,
-                        bands,
+                        bandnames,
                         feature_type=feature_type,
                     )  # type: ignore
                 timings.append(("format", round(t.elapsed * 1000, 2)))
@@ -220,7 +241,9 @@ class viz:
 
                 with Timer() as t:
                     content = image.render(
-                        img_format=format.driver, colormap=colormap, **format.profile,
+                        img_format=format.driver,
+                        colormap=image_params.colormap or dst_colormap,
+                        **format.profile,
                     )
                 timings.append(("format", round(t.from_start * 1000, 2)))
 
@@ -271,6 +294,7 @@ class viz:
                 None, description="Coma (',') delimited band indexes"
             ),
             max_size: int = 1024,
+            layer_params=Depends(self.layer_dependency),
             image_params: ImageParams = Depends(),
         ):
             """Handle /preview requests."""
@@ -279,15 +303,18 @@ class viz:
 
             with Timer() as t:
                 async with self.reader(self.src_path) as src_dst:  # type: ignore
-                    kwargs = self._get_options(src_dst, indexes)
+
+                    # Adapt options for each reader type
+                    kwargs = self._get_options(src_dst, layer_params.kwargs)
+                    if self.nodata is not None:
+                        kwargs["nodata"] = self.nodata
+
                     data = await src_dst.preview(
                         max_size=max_size,
                         resampling_method=image_params.resampling_method.name,
                         **kwargs,
                     )
-                    colormap = image_params.colormap or getattr(
-                        src_dst, "colormap", None
-                    )
+                    dst_colormap = getattr(src_dst, "colormap", None)
             timings.append(("dataread", round(t.elapsed * 1000, 2)))
 
             if not format:
@@ -302,7 +329,9 @@ class viz:
 
             with Timer() as t:
                 content = image.render(
-                    img_format=format.driver, colormap=colormap, **format.profile,
+                    img_format=format.driver,
+                    colormap=image_params.colormap or dst_colormap,
+                    **format.profile,
                 )
             timings.append(("format", round(t.from_start * 1000, 2)))
 
@@ -356,6 +385,7 @@ class viz:
                 None, description="Coma (',') delimited band indexes"
             ),
             max_size: int = 1024,
+            layer_params=Depends(self.layer_dependency),
             image_params: ImageParams = Depends(),
         ):
             """Handle /part requests."""
@@ -364,16 +394,19 @@ class viz:
 
             with Timer() as t:
                 async with self.reader(self.src_path) as src_dst:  # type: ignore
-                    kwargs = self._get_options(src_dst, indexes)
+
+                    # Adapt options for each reader type
+                    kwargs = self._get_options(src_dst, layer_params.kwargs)
+                    if self.nodata is not None:
+                        kwargs["nodata"] = self.nodata
+
                     data = await src_dst.part(
                         list(map(float, bbox.split(","))),
                         max_size=max_size,
                         resampling_method=image_params.resampling_method.name,
                         **kwargs,
                     )
-                    colormap = image_params.colormap or getattr(
-                        src_dst, "colormap", None
-                    )
+                    dst_colormap = getattr(src_dst, "colormap", None)
             timings.append(("dataread", round(t.elapsed * 1000, 2)))
 
             if not format:
@@ -388,7 +421,9 @@ class viz:
 
             with Timer() as t:
                 content = image.render(
-                    img_format=format.driver, colormap=colormap, **format.profile,
+                    img_format=format.driver,
+                    colormap=image_params.colormap or dst_colormap,
+                    **format.profile,
                 )
             timings.append(("format", round(t.from_start * 1000, 2)))
 
@@ -404,11 +439,15 @@ class viz:
             coordinates: str = Query(
                 ..., description="Coma (',') delimited lon,lat coordinates"
             ),
+            layer_params=Depends(self.layer_dependency),
         ):
             """Handle /point requests."""
             lon, lat = list(map(float, coordinates.split(",")))
             async with self.reader(self.src_path) as src_dst:  # type: ignore
-                kwargs = self._get_options(src_dst)
+                kwargs = self._get_options(src_dst, layer_params.kwargs)
+                if self.nodata is not None:
+                    kwargs["nodata"] = self.nodata
+
                 results = await src_dst.point(lon, lat, **kwargs)
 
             return {"coordinates": [lon, lat], "value": results}
@@ -424,13 +463,15 @@ class viz:
             pmin: float = 2.0,
             pmax: float = 98.0,
             max_size: int = 1024,
-            indexes: Optional[str] = Query(
-                None, title="Coma (',') delimited band indexes"
-            ),
+            layer_params=Depends(self.layer_dependency),
         ):
             """Handle /metadata requests."""
             async with self.reader(self.src_path) as src_dst:  # type: ignore
-                kwargs = self._get_options(src_dst, indexes)
+                # Adapt options for each reader type
+                kwargs = self._get_options(src_dst, layer_params.kwargs)
+                if self.nodata is not None:
+                    kwargs["nodata"] = self.nodata
+
                 return await src_dst.metadata(pmin, pmax, max_size=max_size, **kwargs)
 
         @self.router.get(
@@ -440,10 +481,11 @@ class viz:
             response_model_exclude_none=True,
             responses={200: {"description": "Return the metadata of the COG."}},
         )
-        async def info():
+        async def info(layer_params=Depends(self.layer_dependency)):
             """Handle /info requests."""
             async with self.reader(self.src_path) as src_dst:  # type: ignore
-                kwargs = self._get_options(src_dst)
+                # Adapt options for each reader type
+                kwargs = self._get_options(src_dst, layer_params.kwargs)
                 return await src_dst.info(**kwargs)
 
         @self.router.get(
@@ -455,9 +497,7 @@ class viz:
         async def tilejson(
             request: Request,
             tile_format: Optional[TileType] = None,
-            indexes: Optional[str] = Query(  # noqa
-                None, description="Coma (',') delimited band indexes"
-            ),
+            layer_params=Depends(self.layer_dependency),  # noqa
             image_params: ImageParams = Depends(),  # noqa
             feature_type: str = Query(  # noqa
                 None, title="Feature type", regex="^(point)|(polygon)$"
@@ -470,10 +510,10 @@ class viz:
 
             tile_url = request.url_for("tile", **kwargs)
 
-            kwargs = dict(request.query_params)
-            kwargs.pop("tile_format", None)
-            qs = urllib.parse.urlencode(list(kwargs.items()))
+            qs = str(request.query_params)
             if qs:
+                if "tile_format" in qs:
+                    qs = qs.replace(f"tile_format={tile_format.value}", "")
                 tile_url += f"?{qs}"
 
             async with self.reader(self.src_path) as src_dst:  # type: ignore
@@ -499,8 +539,15 @@ class viz:
         )
         async def viewer(request: Request):
             """Handle /index.html."""
+            if self.reader_type == "cog":
+                name = "index.html"
+            elif self.reader_type == "bands":
+                name = "bands.html"
+            elif self.reader_type == "assets":
+                name = "assets.html"
+
             return templates.TemplateResponse(
-                name="index.html",
+                name=name,
                 context={
                     "request": request,
                     "tilejson_endpoint": request.url_for("tilejson"),
@@ -519,9 +566,7 @@ class viz:
             tile_format: ImageType = Query(
                 ImageType.png, description="Output image type. Default is png."
             ),
-            indexes: Optional[str] = Query(  # noqa
-                None, description="Coma (',') delimited band indexes"
-            ),
+            layer_params=Depends(self.layer_dependency),  # noqa
             image_params: ImageParams = Depends(),  # noqa
             feature_type: str = Query(  # noqa
                 None, title="Feature type", regex="^(point)|(polygon)$"

--- a/rio_viz/dependencies.py
+++ b/rio_viz/dependencies.py
@@ -26,14 +26,84 @@ class ImageParams:
         None, description="rio-tiler's colormap name"
     )
     resampling_method: ResamplingNames = Query(
-        ResamplingNames.nearest, description="Resampling method."  # type: ignore
+        None, description="Resampling method."  # type: ignore
     )
     rescale_range: Optional[List[Union[float, int]]] = field(init=False)
     colormap: Optional[Dict[int, Tuple[int, int, int, int]]] = field(init=False)
 
     def __post_init__(self):
         """Post Init."""
+        if self.resampling_method is None:
+            self.resampling_method = ResamplingNames.nearest
+
         self.rescale_range = (
             list(map(float, self.rescale.split(","))) if self.rescale else None
         )
+
         self.colormap = self.color_map.data if self.color_map else None
+
+
+@dataclass
+class DefaultDependency:
+    """Dependency Base Class"""
+
+    kwargs: Dict = field(init=False, default_factory=dict)
+
+
+# Dependencies for simple BaseReader
+@dataclass
+class IndexesParams(DefaultDependency):
+    """Band Indexes parameters."""
+
+    bidx: Optional[List[int]] = Query(
+        None, title="Band indexes", description="band indexes",
+    )
+
+    def __post_init__(self):
+        """Post Init."""
+        if self.bidx is not None:
+            self.kwargs["indexes"] = self.bidx
+
+
+# Dependencies for  MultiBaseReader
+@dataclass
+class AssetsParams(DefaultDependency):
+    """Asset and Band indexes parameters."""
+
+    asset: Optional[List[str]] = Query(
+        None, title="Asset indexes", description="asset names."
+    )
+    bidx: Optional[List[int]] = Query(
+        None, title="Band indexes", description="band indexes",
+    )
+
+    default_asset: Optional[List[str]] = field(init=False)
+
+    def __post_init__(self):
+        """Post Init."""
+        if self.asset or self.default_asset:
+            self.kwargs["assets"] = self.asset or self.default_asset
+        if self.bidx is not None:
+            self.kwargs["indexes"] = self.bidx
+
+
+# Dependencies for  MultiBandReader
+@dataclass
+class BandsParams(DefaultDependency):
+    """Band names parameters."""
+
+    band: Optional[List[str]] = Query(
+        None, title="bands names", description="bands names.",
+    )
+    bidx: Optional[List[int]] = Query(
+        [1], title="Band indexes", description="band indexes",
+    )
+
+    default_band: Optional[List[str]] = field(init=False)
+
+    def __post_init__(self):
+        """Post Init."""
+        if self.band or self.default_band:
+            self.kwargs["bands"] = self.band or self.default_band
+        if self.bidx is not None:
+            self.kwargs["indexes"] = self.bidx

--- a/rio_viz/templates/assets.html
+++ b/rio_viz/templates/assets.html
@@ -1,0 +1,974 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset='utf-8' />
+        <title>rio-viz Multi</title>
+        <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+
+        <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.js'></script>
+        <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.css' rel='stylesheet' />
+
+        <link href='https://api.mapbox.com/mapbox-assembly/v0.23.2/assembly.min.css' rel='stylesheet'>
+        <script src='https://api.mapbox.com/mapbox-assembly/v0.23.2/assembly.js'></script>
+        <script src="https://d3js.org/d3.v4.js"></script>
+        <style>
+            body {
+                margin: 0;
+                padding: 0;
+                width: 100%;
+                height: 100%;
+            }
+
+            #map {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                width: 100%;
+            }
+
+            .zoom-info {
+                z-index: 10;
+                position: absolute;
+                bottom: 17px;
+                right: 0;
+                padding: 5px;
+                width: auto;
+                height: auto;
+                font-size: 12px;
+                color: #000;
+            }
+
+            .loading-map {
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                color: #FFF;
+                background-color: #000;
+                text-align: center;
+                opacity: 0.5;
+                font-size: 45px;
+            }
+
+            .loading-map.off {
+                opacity: 0;
+                -o-transition: all .5s ease;
+                -webkit-transition: all .5s ease;
+                -moz-transition: all .5s ease;
+                -ms-transition: all .5s ease;
+                transition: all ease .5s;
+                visibility: hidden;
+            }
+
+            .middle-center {
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                transform: translate(-50%, -50%);
+            }
+
+            .middle-center * {
+                display: block;
+                padding: 5px;
+            }
+
+            #menu {
+                left: 0;
+                top: 0;
+                -o-transition: all .5s ease;
+                -webkit-transition: all .5s ease;
+                -moz-transition: all .5s ease;
+                -ms-transition: all .5s ease;
+                transition: all ease .5s;
+            }
+
+            #menu.off {
+                left: -360px;
+                -o-transition: all .5s ease;
+                -webkit-transition: all .5s ease;
+                -moz-transition: all .5s ease;
+                -ms-transition: all .5s ease;
+                transition: all ease .5s;
+            }
+
+            #toolbar {
+                height: 20px;
+            }
+
+            #toolbar li {
+                display: block;
+                color: #000;
+                background-color: #fff;
+                font-weight: 700;
+                font-size: 12px;
+                padding: 3px;
+                height: 100%;
+                width: 100%;
+                text-transform: uppercase;
+                text-align: center;
+                text-decoration: none;
+                outline: 0;
+                cursor: pointer;
+                -webkit-touch-callout: none;
+                -webkit-user-select: none;
+                -moz-user-select: none;
+                -ms-user-select: none;
+                user-select: none;
+            }
+
+            #toolbar li svg {
+                font-size: 16px;
+                line-height: 16px;
+            }
+
+            #toolbar li:hover {
+                background-color: #ddd;
+            }
+
+            #toolbar li.active {
+                color: #fff;
+                background-color: #000;
+            }
+
+            #toolbar li.disabled {
+                pointer-events: none;
+                opacity: 0.4;
+            }
+
+            #menu-content section {
+                display: none;
+            }
+
+            #menu-content section.active {
+                display: inherit;
+            }
+
+            #hide-arrow {
+                -o-transition: all .5s ease;
+                -webkit-transition: all .5s ease;
+                -moz-transition: all .5s ease;
+                -ms-transition: all .5s ease;
+                transition: all ease .5s;
+            }
+
+            #hide-arrow.off {
+                transform: rotate(-180deg);
+            }
+
+            input:checked+.toggle {
+                background: #fff;
+                border: #000;
+            }
+
+            #btn-hide {
+                position: absolute;
+                top: 0;
+                height: 35px;
+                font-size: 35px;
+                line-height: 35px;
+                vertical-align: middle;
+                right: -35px;
+                color: #28333b;
+                background-color: #fff;
+            }
+
+            #btn-hide:hover {
+                color: #fff;
+                background-color: #28333b;
+                cursor: pointer;
+            }
+
+            .line-red {
+                fill: none;
+                stroke: red;
+                stroke-width: 1.5px;
+            }
+
+            .line-green {
+                fill: none;
+                stroke: green;
+                stroke-width: 1.5px;
+            }
+
+            .line-blue {
+                fill: none;
+                stroke: blue;
+                stroke-width: 1.5px;
+            }
+
+            @media(max-width: 767px) {
+
+                #menu.off {
+                    left: -240px;
+                    -o-transition: all .5s ease;
+                    -webkit-transition: all .5s ease;
+                    -moz-transition: all .5s ease;
+                    -ms-transition: all .5s ease;
+                    transition: all ease .5s;
+                }
+
+                .mapboxgl-ctrl-attrib {
+                    font-size: 10px;
+                }
+            }
+        </style>
+    </head>
+    <body>
+        <div id='menu' class='flex-child w240 w360-ml absolute bg-gray-faint z2 off'>
+
+            <div id='asset-section' class='px6 py6 wmax-full'>
+                <div class='txt-h5 mb6 color-black'><svg class='icon icon--l inline-block'><use xlink:href='#icon-layers' /></svg>Assets</div>
+                <div class='select-container'>
+                    <select id='asset-selector' class='select select--s select--stroke pl6 wmax-full'></select>
+                    <div class='select-arrow color-black'></div>
+                </div>
+
+                <div class='pt6'>Allow assets composition</div>
+                <label class='switch-container'>
+                    <input id='compose-switch' type='checkbox' />
+                    <div class='switch'></div>
+                </label>
+            </div>
+
+            <ul id='toolbar' class='grid'>
+                <li id='3b' class="col col--6 active" title="rgb" onclick="switchPane(this)">
+                    <svg class='icon icon--l inline-block'><use xlink:href='#icon-menu' /></svg>
+                </li>
+                <li id='1b' class="col col--6" title="band" onclick="switchPane(this)">
+                    <svg class='icon icon--l inline-block'><use xlink:href='#icon-minus' /></svg>
+                </li>
+            </ul>
+
+            <div id='menu-content' class='relative'>
+
+                <!-- RGB Selection -->
+                <section id='3b-section' class='px12 pt12 pb6 active'>
+                    <div class='txt-h5 mb6 color-black'><svg class='icon icon--l inline-block'><use xlink:href='#icon-layers' /></svg> RGB</div>
+                    <div id='rgb-buttons' class='align-center px6 py6'>
+                        <div class='select-container'>
+                            <select id='r-selector' class='select select--s select--stroke wmax-full color-red'></select>
+                            <div class='select-arrow color-black'></div>
+                        </div>
+
+                        <div class='select-container'>
+                            <select id='g-selector' class='select select--s select--stroke wmax-full color-green'></select>
+                            <div class='select-arrow color-black'></div>
+                        </div>
+
+                        <div class='select-container'>
+                            <select id='b-selector' class='select select--s select--stroke wmax-full color-blue'></select>
+                            <div class='select-arrow color-black'></div>
+                        </div>
+                    </div>
+
+                    <!-- 3b Histogram -->
+                    <div>
+                        <div class='txt-h5 mt6 mb6 color-black'><svg class='icon icon--l inline-block'><use xlink:href='#icon-graph'/></svg> Histogram</div>
+                        <div id="histogram3b" class="w-full h120 h240-ml relative"></div>
+                    </div>
+                </section>
+
+                <!-- 1 Band Selection -->
+                <section id='1b-section' class='px12 pt12 pb6'>
+                    <div class='txt-h5 mb6 color-black'>
+                        <svg class='icon icon--l inline-block'><use xlink:href='#icon-layers' /></svg> Layers
+                    </div>
+                    <div class='select-container wmax-full'>
+                        <select id='layer-selector' class='select select--s select--stroke wmax-full color-black'></select>
+                        <div class='select-arrow color-black'></div>
+                    </div>
+
+                    <!-- 1b Histogram -->
+                    <div>
+                        <div class='txt-h5 mt6 mb6 color-black'><svg class='icon icon--l inline-block'><use xlink:href='#icon-graph'/></svg> Histogram</div>
+                        <div id="histogram1b" class="w-full h120 h240-ml relative"></div>
+                    </div>
+
+                    <!-- Color Map -->
+                    <div id='colormap-section'>
+                        <div class='txt-h5 mt6 mb6 color-black'><svg class='icon icon--l inline-block'>
+                                <use xlink:href='#icon-palette' /></svg> Color Map</div>
+                        <div class='select-container wmax-full'>
+                            <select id='colormap-selector' class='select select--s select--stroke wmax-full color-black'>
+                                <option value='b&w'>Internal</option>
+                                <option value=cfastie>CFastie</option>
+                                <option value=rplumbo>RPlumbo</option>
+                                <option value=schwarzwald>Schwarzwald (elevation)</option>
+                                <option value=viridis>Viridis</option>
+                                <option value=rdbu_r>Blue-Red</option>
+                                <option value=bugn>Blue-Green</option>
+                                <option value=ylgn>Yellow-Green</option>
+                                <option value=magma>Magma</option>
+                                <option value=gist_earth>Earth</option>
+                                <option value=ocean>Ocean</option>
+                                <option value=terrain>Terrain</option>
+                            </select>
+                            <div class='select-arrow color-black'></div>
+                        </div>
+                    </div>
+                </section>
+
+                <div id='rescale-section' class='px6 py6'>
+                    <div class='txt-h5 mb6 color-black'>Histogram min/max</div>
+                    <div>
+                        <input id="min-value" class='input input--s wmax60 inline-block align-center color-black' value='0' />
+                        <input id="max-value" class='input input--s wmax60 inline-block align-center color-black' value='1000' />
+                    </div>
+                </div>
+
+                <div id='cformula-section' class='px6 py6'>
+                    <div class='txt-h5 mb6 color-black'>Color Formula</div>
+                    <input id="ColorFormulaValue" class='input input--s w-full color-black' value='' />
+                </div>
+                <button id="updateColor" class='btn bts--xs btn--stroke bg-darken25-on-hover txt-s color-black ml12'>Apply</button>
+
+                <!-- Resampling -->
+                <div class='px12 pt12 pb6'>
+                    <div class='txt-h5 mt6 mb6 color-black'>Resampling Method</div>
+                    <div id='resamp-selector' class='toggle-group bg-gray-faint mt6 mb6' style="line-height: 0">
+                        <label class='toggle-container'>
+                            <input value='bilinear' name='toggle-resamp' type='radio' />
+                            <div title='bilinear' class='toggle color-black color-gray-dark-on-hover'>bilinear</div>
+                        </label>
+                        <label class='toggle-container'>
+                            <input value='cubic' name='toggle-resamp' type='radio' />
+                            <div title='cubic' class='toggle color-black color-gray-dark-on-hover'>cubic</div>
+                        </label>
+                        <label class='toggle-container'>
+                            <input value='nearest' checked='checked' name='toggle-resamp' type='radio' />
+                            <div title='nearest' class='toggle color-black color-gray-dark-on-hover'>nearest</div>
+                        </label>
+                    </div>
+                </div>
+            </div>
+            <button id='btn-hide'><svg id='hide-arrow' class='icon'><use xlink:href='#icon-arrow-right' /></svg></button>
+        </div>
+
+        <div id='map'>
+            <div id='loader' class="loading-map z3">
+                <div class="middle-center">
+                    <div class="round animation-spin animation--infinite animation--speed-1">
+                        <svg class='icon icon--l inline-block'>
+                            <use xlink:href='#icon-satellite' /></svg>
+                    </div>
+                </div>
+            </div>
+            <div class="zoom-info"><span id="zoom"></span></div>
+        </div>
+
+        <script>
+var scope = { assets: [], metadata: {} }
+
+mapboxgl.accessToken = '{{ mapbox_access_token  }}'
+
+let style
+if (mapboxgl.accessToken !== '') {
+    style = 'mapbox://styles/mapbox/{{ mapbox_style }}-v9'
+} else {
+    style = { version: 8, sources: {}, layers: [] }
+}
+
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: style,
+    center: [0, 0],
+    zoom: 1
+})
+
+map.on('zoom', function (e) {
+    const z = (map.getZoom()).toString().slice(0, 6)
+    document.getElementById('zoom').textContent = z
+})
+
+const set1bViz = () => {
+    params = {
+        resampling_method: document.getElementById('resamp-selector').querySelector("input[name='toggle-resamp']:checked").value
+    }
+
+    const asset = document.getElementById('asset-selector').value
+    params.asset = asset
+
+    const active_layer = document.getElementById('layer-selector')[document.getElementById('layer-selector').selectedIndex]
+    const bidx = active_layer.getAttribute('band')
+    params.bidx = bidx
+
+    if (['uint8', 'int8', 'byte'].indexOf(scope.metadata[asset].dtype) === -1) {
+        const minV = parseFloat(document.getElementById('min-value').value)
+        const maxV = parseFloat(document.getElementById('max-value').value)
+        params.rescale = `${minV},${maxV}`
+    }
+
+    if (document.getElementById('ColorFormulaValue').value !== '') {
+        params.color_formula = document.getElementById('ColorFormulaValue').value
+    }
+
+    const cmap = document.getElementById('colormap-selector')[document.getElementById('colormap-selector').selectedIndex]
+    if (cmap.value !== 'b&w') params.colormap_name = cmap.value
+
+    const url_params = Object.keys(params).map(i => `${i}=${params[i]}`).join('&')
+    let url = `{{ tilejson_endpoint }}?${url_params}`
+
+    map.addSource('raster', { type: 'raster', url: url, tileSize: 512 })
+    map.addLayer({  id: 'raster', type: 'raster', source: 'raster' })
+
+    document.getElementById('loader').classList.add('off')
+
+    addHisto1Band()
+}
+
+const set3bViz = () => {
+    const r = document.getElementById('r-selector').selectedOptions[0].getAttribute("band")
+    const g = document.getElementById('g-selector').selectedOptions[0].getAttribute("band")
+    const b = document.getElementById('b-selector').selectedOptions[0].getAttribute("band")
+
+    params = {
+        resampling_method: document.getElementById('resamp-selector').querySelector("input[name='toggle-resamp']:checked").value
+    }
+    const composite = document.getElementById("compose-switch").checked
+
+    let assets
+    let indexes
+    if (composite === true) {
+        assets = [r, g, b]
+        indexes = [1]
+        const minV = parseFloat(document.getElementById('min-value').value)
+        const maxV = parseFloat(document.getElementById('max-value').value)
+        params.rescale = `${minV},${maxV}`
+
+    } else {
+        const asset = document.getElementById('asset-selector').value
+        assets = [asset]
+        indexes = [r, g, b]
+
+        if (['uint8', 'int8', 'byte'].indexOf(scope.metadata[asset].dtype) === -1) {
+            const minV = parseFloat(document.getElementById('min-value').value)
+            const maxV = parseFloat(document.getElementById('max-value').value)
+            params.rescale = `${minV},${maxV}`
+        }
+    }
+
+    if (document.getElementById('ColorFormulaValue').value !== '') {
+        params.color_formula = document.getElementById('ColorFormulaValue').value
+    }
+
+    const url_params = Object.keys(params).map(i => `${i}=${params[i]}`).join('&')
+    const asset_params = assets.map(i => `asset=${i}`).join('&')
+    const indexes_params = indexes.map(i => `bidx=${i}`).join('&')
+    let url = `{{ tilejson_endpoint }}?${url_params}&${asset_params}&${indexes_params}`
+
+    map.addSource('raster', { type: 'raster', url: url, tileSize: 512 })
+    map.addLayer({  id: 'raster', type: 'raster', source: 'raster' })
+
+    document.getElementById('loader').classList.add('off')
+
+    addHisto3Bands()
+}
+
+const addHisto3Bands = () => {
+    const r = document.getElementById('r-selector').selectedOptions[0].getAttribute("band")
+    const g = document.getElementById('g-selector').selectedOptions[0].getAttribute("band")
+    const b = document.getElementById('b-selector').selectedOptions[0].getAttribute("band")
+
+    let rStats
+    let gStats
+    let bStats
+    if (document.getElementById("compose-switch").checked === true) {
+        rStats = scope.metadata[r].statistics[1]
+        gStats = scope.metadata[g].statistics[1]
+        bStats = scope.metadata[b].statistics[1]
+    } else {
+        const asset = document.getElementById('asset-selector').value
+        rStats = scope.metadata[asset].statistics[r]
+        gStats = scope.metadata[asset].statistics[g]
+        bStats = scope.metadata[asset].statistics[b]
+    }
+
+    const minV = Math.min(...[rStats.min, gStats.min, bStats.min])
+    const maxV = Math.max(...[rStats.max, gStats.max, bStats.max])
+
+    let rCounts = rStats.histogram[0]
+    let gCounts = gStats.histogram[0]
+    let bCounts = bStats.histogram[0]
+
+    const rValues = rStats.histogram[1]
+    const gValues = gStats.histogram[1]
+    const bValues = bStats.histogram[1]
+
+    const add = (a, b) => a + b
+
+    const sumR = rCounts.reduce(add)
+    const sumG = gCounts.reduce(add)
+    const sumB = bCounts.reduce(add)
+
+    rCounts = rCounts.map((e) => {return e / sumR * 100})
+    gCounts = gCounts.map((e) => {return e / sumG * 100})
+    bCounts = bCounts.map((e) => {return e / sumB * 100})
+    const maxH = Math.max(...rCounts, ...gCounts, ...bCounts)
+
+    const bbox = d3.select('#histogram3b').node().getBoundingClientRect()
+
+    // set the dimensions and margins of the graph
+    const margin = { top: 10, right: 30, bottom: 30, left: 40 }
+    const width = bbox.width - margin.left - margin.right
+    const height = bbox.height - margin.top - margin.bottom
+
+    d3.select('#histogram3b').selectAll('*').remove()
+    // append the svg object to the body of the page
+    var svg = d3.select('#histogram3b')
+    .append('svg')
+    .attr('width', width + margin.left + margin.right)
+    .attr('height', height + margin.top + margin.bottom)
+    .append('g')
+    .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')')
+
+    // X axis: scale and draw:
+    var x = d3.scaleLinear()
+    .domain([minV, maxV])
+    .range([0, width])
+
+    svg.append('g')
+    .attr('transform', 'translate(0,' + height + ')')
+    .call(d3.axisBottom(x))
+
+    // Y axis: scale and draw:
+    var y = d3.scaleLinear().range([height, 0])
+    y.domain([0, maxH + 5])
+    svg.append('g').call(d3.axisLeft(y))
+
+    const addLine = (counts, values, color) => {
+    const data = []
+    for (var i = 0; i < counts.length; i++) {
+        data.push({count: counts[i], value: values[i]})
+    }
+
+    var guide = d3.line()
+                    .x(function(d){ return x(d.value) })
+                    .y(function(d){ return y(d.count) });
+
+    var line = svg.append('path')
+                    .datum(data)
+                    .attr('d', guide)
+                    .attr('class', `line-${color}`);
+    }
+    addLine(rCounts, rValues, "red")
+    addLine(gCounts, gValues, "green")
+    addLine(bCounts, bValues, "blue")
+
+    //Draw axes
+    svg.append("g")
+        .attr("class", "x axis")
+        .attr("transform", "translate(0," + maxH + 5 + ")")
+        .call(x);
+
+    svg.append("g")
+        .attr("class", "y axis")
+        .call(y)
+        .append("text")
+        .attr("transform", "rotate(-90)")
+        .attr("y", 6)
+        .attr("dy", ".71em")
+        .style("text-anchor", "end")
+}
+
+const addHisto1Band = () => {
+    const asset = document.getElementById('asset-selector').value
+    const active_layer = document.getElementById('layer-selector')[document.getElementById('layer-selector').selectedIndex]
+    const stats = scope.metadata[asset].statistics[active_layer.getAttribute('band')]
+
+    let counts = stats.histogram[0]
+    const sum = counts.reduce(function(a, b){
+        return a + b;
+    }, 0);
+    counts = counts.map((e) => {return e / sum * 100})
+    const maxH = Math.max(...counts)
+
+    const values = stats.histogram[1]
+    const bbox = d3.select('#histogram1b').node().getBoundingClientRect()
+
+    // set the dimensions and margins of the graph
+    const margin = { top: 10, right: 30, bottom: 30, left: 40 }
+    const width = bbox.width - margin.left - margin.right
+    const height = bbox.height - margin.top - margin.bottom
+
+    d3.select('#histogram1b').selectAll('*').remove()
+    // append the svg object to the body of the page
+    var svg = d3.select('#histogram1b')
+        .append('svg')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')')
+
+    const min = stats.min
+    const max = stats.max
+
+    // X axis: scale and draw:
+    var x = d3.scaleLinear()
+        .domain([min, max])
+        .range([0, width])
+
+    svg.append('g')
+        .attr('transform', 'translate(0,' + height + ')')
+        .call(d3.axisBottom(x))
+
+    // Y axis: scale and draw:
+    var y = d3.scaleLinear().range([height, 0])
+        .domain([0, maxH])
+
+    svg.append('g').call(d3.axisLeft(y))
+
+    const bins = []
+    for (var i = 0; i < counts.length; i++) {
+    bins.push({
+        count: counts[i],
+        value: values[i]
+    })
+    }
+
+    // append the bar rectangles to the svg element
+    svg.selectAll('rect')
+        .data(bins)
+        .enter()
+        .append('rect')
+        .attr('x', 1)
+        .attr('transform', d => { return 'translate(' + x(d.value) + ',' + y(d.count) + ')' })
+        .attr('width', 10)
+        .attr('height', d => { return height - y(d.count) })
+        .style('fill', '#69b3a2')
+}
+
+const switchViz = () => {
+    if (map.getLayer('raster')) map.removeLayer('raster')
+    if (map.getSource('raster')) map.removeSource('raster')
+
+    const rasterType = document.getElementById('toolbar').querySelector(".active").id
+    switch (rasterType) {
+        case '1b':
+            set1bViz()
+            break
+        case '3b':
+            set3bViz()
+            break
+        default:
+            throw new Error(`Invalid ${rasterType}`)
+    }
+}
+
+document.getElementById('btn-hide').addEventListener('click', () => {
+    document.getElementById('hide-arrow').classList.toggle('off')
+    document.getElementById('menu').classList.toggle('off')
+})
+
+document.getElementById('resamp-selector').addEventListener('change', (e) => {
+    switchViz()
+})
+
+document.getElementById('layer-selector').addEventListener('change', () => {
+    switchViz()
+})
+
+document.getElementById('asset-selector').addEventListener('change', () => {
+    updateUI()
+    switchViz()
+})
+
+document.getElementById('compose-switch').addEventListener('change', () => {
+    updateUI()
+})
+
+document.getElementById('r-selector').addEventListener('change', () => { switchViz() })
+document.getElementById('g-selector').addEventListener('change', () => { switchViz() })
+document.getElementById('b-selector').addEventListener('change', () => { switchViz() })
+
+document.getElementById('colormap-selector').addEventListener('change', () => {
+    switchViz()
+})
+
+document.getElementById('updateColor').addEventListener('click', () => {
+    switchViz()
+})
+
+const switchPane = (event) => {
+    const cur = document.getElementById('toolbar').querySelector(".active")
+    const activeViz = cur.id
+    const nextViz = event.id
+    cur.classList.toggle('active')
+    event.classList.toggle('active')
+
+    const curSection = document.getElementById(`${activeViz}-section`)
+    curSection.classList.toggle('active')
+    const nextSection = document.getElementById(`${nextViz}-section`)
+    nextSection.classList.toggle('active')
+    switchViz()
+}
+
+const bboxPolygon = (bounds) => {
+    return {
+        'type': 'Feature',
+        'geometry': {
+            'type': 'Polygon',
+            'coordinates': [[
+                [bounds[0], bounds[1]],
+                [bounds[2], bounds[1]],
+                [bounds[2], bounds[3]],
+                [bounds[0], bounds[3]],
+                [bounds[0], bounds[1]]
+            ]]
+        },
+        'properties': {}
+    }
+}
+
+const addAOI = (bounds) => {
+    if (map.getLayer('aoi-polygon')) map.removeLayer('aoi-polygon')
+    if (map.getSource('aoi')) map.removeSource('aoi')
+
+
+    const geojson = {
+        "type": "FeatureCollection",
+        "features": [bboxPolygon(bounds)]
+    }
+
+    map.addSource('aoi', {
+        'type': 'geojson',
+        'data': geojson
+    })
+
+    map.addLayer({
+        id: 'aoi-polygon',
+        type: 'line',
+        source: 'aoi',
+        layout: {
+            'line-cap': 'round',
+            'line-join': 'round'
+        },
+        paint: {
+            'line-color': '#3bb2d0',
+            'line-width': 1
+        }
+    })
+    return
+}
+
+const truncate_lnglat = (lng, lat) => {
+    if (lng > 180.0) {
+        lng = 180.0
+    } else if (lng < -180.0) {
+        lng = -180.0
+    }
+    if (lat > 90.0) {
+        lat = 90.0
+    } else if (lat < -90.0) {
+        lat = -90.0
+    }
+    return [lng, lat]
+}
+
+const updateUI = () => {
+    const is_checked = document.getElementById("compose-switch").checked
+
+    const rList = document.getElementById('r-selector')
+    rList.innerHTML = ''
+    const bList = document.getElementById('b-selector')
+    bList.innerHTML = ''
+    const gList = document.getElementById('g-selector')
+    gList.innerHTML = ''
+
+    if (is_checked === true) {
+        document.getElementById('asset-selector').classList.add('disabled')
+        document.getElementById("asset-selector").disabled = true
+
+        document.getElementById('3b').classList.add('active')
+        document.getElementById('3b').classList.remove('disabled')
+        document.getElementById('3b-section').classList.add('active')
+
+        document.getElementById('1b').classList.remove('active')
+        document.getElementById('1b').classList.add('disabled')
+        document.getElementById('1b-section').classList.remove('active')
+
+        const nbands = scope.assets.length
+
+        for (var i = 0; i < nbands; i++) {
+            let l = document.createElement('option')
+            l.value = scope.assets[i]
+            l.setAttribute('band', scope.assets[i])
+            l.text = scope.assets[i]
+            if (i === 0) l.selected = "selected"
+            rList.appendChild(l)
+        }
+
+        for (var i = 0; i < nbands; i++) {
+            let l = document.createElement('option')
+            l.value = scope.assets[i]
+            l.setAttribute('band', scope.assets[i])
+            l.text = scope.assets[i]
+            if (i === 1) l.selected = "selected"
+            gList.appendChild(l)
+        }
+
+        for (var i = 0; i < nbands; i++) {
+            let l = document.createElement('option')
+            l.value = scope.assets[i]
+            l.setAttribute('band', scope.assets[i])
+            l.text = scope.assets[i]
+            l.selected = "selected"
+            bList.appendChild(l)
+        }
+
+        document.getElementById('rescale-section').classList.remove('none')
+
+    } else {
+        document.getElementById('1b').classList.remove('disabled')
+        document.getElementById("asset-selector").disabled = false
+
+        const layerList = document.getElementById('layer-selector')
+        layerList.innerHTML = ''
+
+        const asset = document.getElementById('asset-selector').value
+        const metadata = scope.metadata[asset]
+        const band_descr = metadata.band_descriptions
+        const nbands = band_descr.length
+
+        //1 band
+        for (var i = 0; i < nbands; i++) {
+            let l = document.createElement('option')
+            l.setAttribute('band', band_descr[i][0])
+            let name = band_descr[i][1] || band_descr[i][0]
+            l.setAttribute('name', name)
+            l.text = name
+            layerList.appendChild(l)
+        }
+
+        //RGB
+        const rList = document.getElementById('r-selector')
+        for (var i = 0; i < nbands; i++) {
+            let l = document.createElement('option')
+            l.setAttribute('band', band_descr[i][0])
+            let name = band_descr[i][1] || band_descr[i][0]
+            l.setAttribute('name', name)
+            l.text = name
+            if (i === 0) l.selected = "selected"
+            rList.appendChild(l)
+        }
+
+        const gList = document.getElementById('g-selector')
+        for (var i = 0; i < nbands; i++) {
+            let l = document.createElement('option')
+            l.setAttribute('band', band_descr[i][0])
+            let name = band_descr[i][1] || band_descr[i][0]
+            l.setAttribute('name', name)
+            l.text = name
+            if (i === 1) l.selected = "selected"
+            gList.appendChild(l)
+        }
+
+        const bList = document.getElementById('b-selector')
+        for (var i = 0; i < nbands; i++) {
+            let l = document.createElement('option')
+            l.setAttribute('band', band_descr[i][0])
+            let name = band_descr[i][1] || band_descr[i][0]
+            l.setAttribute('name', name)
+            l.text = name
+            if (band_descr.length > 2 && i === 2) {
+                l.selected = "selected"
+            } else {
+                l.selected = "selected"
+            }
+            bList.appendChild(l)
+        }
+
+        if (['uint8', 'int8', 'byte'].indexOf(metadata.dtype) === -1) {
+            document.getElementById('rescale-section').classList.remove('none')
+        } else {
+            document.getElementById('rescale-section').classList.add('none')
+        }
+
+        const bounds = metadata.bounds
+        map.fitBounds([[bounds[0], bounds[1]], [bounds[2], bounds[3]]])
+        addAOI(bounds)
+
+        if (nbands === 1) {
+            document.getElementById('3b').classList.add('disabled')
+            document.getElementById('3b').classList.remove('active')
+            document.getElementById('3b-section').classList.remove('active')
+            document.getElementById('1b').classList.add('active')
+            document.getElementById('1b-section').classList.add('active')
+        } else {
+            document.getElementById('3b').classList.remove('disabled')
+        }
+    }
+
+    switchViz()
+}
+
+map.on('load', () => {
+
+    // // we cannot click on raster layer (mapbox-gl bug)
+    // map.on('click', (e) => {
+    //     if (!map.getLayer('raster')) return
+    //     const bounds = map.getSource('raster').bounds
+    //     if (
+    //         (e.lngLat.lng >= bounds[0] && e.lngLat.lng <= bounds[2]) &&
+    //         (e.lngLat.lat >= bounds[1] && e.lngLat.lat <= bounds[3])
+    //     ) {
+    //         const coord = `${e.lngLat.lng},${e.lngLat.lat}`
+    //         fetch(`${point_endpoint}?coordinates=${coord}`)
+    //         .then(res => {
+    //             if (res.ok) return res.json()
+    //             throw new Error('Network response was not ok.');
+    //         })
+    //         .then(data => {
+    //             let html = '<table><tr><th class="align-l">property</th><th class="px3 align-r">value</th></tr>'
+    //             let values = Object.keys(data.value)
+    //             for (var i = 0; i < values.length; i++) {
+    //             let value = data.value[values[i]]
+    //             let key = scope.metadata.band_descriptions[i][1] || scope.metadata.band_descriptions[i][0]
+    //             html += `<tr><td class="align-l">${key}</td><td class="px3 align-r">${value}</td></tr>`
+    //             }
+    //             html += `<tr><td class="align-l">lon</td><td class="px3 align-r">${e.lngLat.lng.toString().slice(0, 7)}</td></tr>`
+    //             html += `<tr><td class="align-l">lat</td><td class="px3 align-r">${e.lngLat.lat.toString().slice(0, 7)}</td></tr>`
+    //             html += '</table>'
+    //             new mapboxgl.Popup()
+    //             .setLngLat(e.lngLat)
+    //             .setHTML(html)
+    //             .addTo(map)
+    //         })
+    //         .catch(err => {
+    //             console.warn(err)
+    //         })
+    //     }
+    //})
+
+
+    fetch('{{ metadata_endpoint }}?max_size=256')
+        .then(res => {
+            if (res.ok) return res.json()
+            throw new Error('Network response was not ok.')
+        })
+        .then(data => {
+            document.getElementById('hide-arrow').classList.toggle('off')
+            document.getElementById('menu').classList.toggle('off')
+            document.getElementById('loader').classList.toggle('off')
+
+            scope.assets =  Object.entries(data).map((e) => {return e[0]})
+            scope.metadata = data
+
+            const assetList = document.getElementById('asset-selector')
+            for (var i = 0; i < scope.assets.length; i++) {
+                let l = document.createElement('option')
+                l.value = scope.assets[i]
+                l.setAttribute('data-asset', scope.assets[i])
+                l.text = scope.assets[i]
+                assetList.appendChild(l)
+            }
+
+        })
+        .then(() => {
+            updateUI()
+        })
+        .catch(err => {
+            console.warn(err)
+        })
+})
+        </script>
+    </body>
+</html>

--- a/rio_viz/templates/bands.html
+++ b/rio_viz/templates/bands.html
@@ -400,12 +400,12 @@
       switch (vizType) {
         case 'raster':
           const active_layer = document.getElementById('layer-selector')[document.getElementById('layer-selector').selectedIndex]
-          indexes = active_layer.getAttribute('band')
-          params.bidx = indexes
+          band = active_layer.getAttribute('band')
+          params.band = band
 
           if (document.getElementById('histcut-selector').querySelector("input[name='toggle-histo']:checked").value !== 'none') {
-            const minV = scope.config[indexes].min
-            const maxV = scope.config[indexes].max
+            const minV = scope.config[band].min
+            const maxV = scope.config[band].max
             params.rescale =  `${minV},${maxV}`
           }
           const cmap = document.getElementById('colormap-selector')[document.getElementById('colormap-selector').selectedIndex]
@@ -458,8 +458,8 @@
         params.rescale =  `${min1},${max1},${min2},${max2},${min3},${max3}`
       }
       const url_params = Object.keys(params).map(i => `${i}=${params[i]}`).join('&')
-      const indexes_params = [r, g, b].map(i => `bidx=${i}`).join('&')
-      let url = `${tilejson_endpoint}?${url_params}&${indexes_params}`
+      const bands_params = [r, g, b].map(i => `band=${i}`).join('&')
+      let url = `${tilejson_endpoint}?${url_params}&${bands_params}`
 
       map.addSource('raster', { type: 'raster', url: url, tileSize: 256})
       map.addLayer({id: 'raster', type: 'raster', source: 'raster'})
@@ -491,10 +491,10 @@
       if (map.getLayer('mvt')) map.removeLayer('mvt')
 
       const active_layer = document.getElementById('layer-selector')[document.getElementById('layer-selector').selectedIndex]
-      const indexes = active_layer.getAttribute('band')
+      const band = active_layer.getAttribute('band')
 
-      let sMin = scope.config[indexes].min
-      const sMax = scope.config[indexes].max
+      let sMin = scope.config[band].min
+      const sMax = scope.config[band].max
       if (sMin === sMax) sMin = sMin - 0.00001
 
       addHisto1Band()

--- a/rio_viz/templates/bands.html
+++ b/rio_viz/templates/bands.html
@@ -294,7 +294,7 @@
 
           <!-- V Exag -->
           <div id='extrusion-section' class='none'>
-            <div class='txt-h5 mt6 mb6 color-black'>Vercital Exageration</div>
+            <div class='txt-h5 mt6 mb6 color-black'>Vercital Exaggeration</div>
             <div class='px6 py6'>
               <input id="ex-value" class='input input--s wmax60 inline-block align-center color-black' value='1' />
               <button id="updateExag" class='btn bts--xs btn--stroke bg-darken25-on-hover inline-block txt-s color-black ml12'>Apply</button>

--- a/rio_viz/templates/index.html
+++ b/rio_viz/templates/index.html
@@ -294,7 +294,7 @@
 
           <!-- V Exag -->
           <div id='extrusion-section' class='none'>
-            <div class='txt-h5 mt6 mb6 color-black'>Vercital Exageration</div>
+            <div class='txt-h5 mt6 mb6 color-black'>Vercital Exaggeration</div>
             <div class='px6 py6'>
               <input id="ex-value" class='input input--s wmax60 inline-block align-center color-black' value='1' />
               <button id="updateExag" class='btn bts--xs btn--stroke bg-darken25-on-hover inline-block txt-s color-black ml12'>Apply</button>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -38,12 +38,12 @@ def test_viz():
     assert response.headers["content-type"] == "image/png"
 
     response = client.get(
-        "/tiles/7/64/43.png?rescale=1,10&indexes=1&color_formula=Gamma R 3"
+        "/tiles/7/64/43.png?rescale=1,10&bidx=1&color_formula=Gamma R 3"
     )
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/png"
 
-    response = client.get("/tiles/7/64/43.png?rescale=1,10&indexes=1,1,1")
+    response = client.get("/tiles/7/64/43.png?rescale=1,10&bidx=1&bidx=1&bidx=1")
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/png"
 


### PR DESCRIPTION
This PR refactor how rio-viz is dealing with different rio-tiler BaseReader. 

```
$ rio viz cog.tif
$ rio viz item.json --reader rio_tiler.io.stac.STACReader
$ rio viz LC08_L1TP_013031_20130930_20170308_01_T1 --reader rio_tiler_pds.landsat.aws.landsat8.L8Reader --layers B1,B2
```

Before we were using a `hack` where we used `indexes` query parameter to pass indexes/bands/assets, with this PR we add dynamic dependency meaning that dependency will be created specifically for each reader type.

This PR also adds a better UI for MultiBaseReader (STAC) inspired from the one TiTiler use.

![](https://user-images.githubusercontent.com/10407788/112190713-a4910c00-8bdb-11eb-803a-01304e01928e.png)
